### PR TITLE
Fixed profile when adding and deleting certifications

### DIFF
--- a/client/src/components/Inbox/CustInboxPage.js
+++ b/client/src/components/Inbox/CustInboxPage.js
@@ -104,7 +104,6 @@ function CustInboxPage() {
 
   return (
     <div className={classes.root}>
-      <NavBar />
       <Typography variant="h4" className={classes.title}>
         Inbox
       </Typography>

--- a/client/src/components/Inbox/ServInboxPage.js
+++ b/client/src/components/Inbox/ServInboxPage.js
@@ -104,7 +104,6 @@ function ServInboxPage() {
 
   return (
     <div className={classes.root}>
-      <NavBar />
       <Typography variant="h4" className={classes.title}>
         Inbox
       </Typography>

--- a/client/src/components/Inbox/index.js
+++ b/client/src/components/Inbox/index.js
@@ -86,7 +86,7 @@ function InboxPage() {
   let token = Cookies.getItem("token");
   const decodedToken = jwt_decode(token);
   console.log("decoded token is ", decodedToken);
-  let userObj = decodedToken["obj"][0];
+  let userObj = decodedToken['tokenObj'];
   console.log("User is ", userObj);
 
   const getRequests = () => {

--- a/client/src/components/MyProfile/ServiceProviderProfile.js
+++ b/client/src/components/MyProfile/ServiceProviderProfile.js
@@ -24,8 +24,8 @@ export default function ServiceProviderProfile(props) {
     const [readOnlyState, setReadOnlyState] = useState(true);
     const [openConfirmDialog, setOpenConfirmDialog] = useState(false);
     const [updatedCert, setUpdatedCert] = useState("");
-    const [editedCerts, setEditedCerts] = useState(false);
     const [openCertModal, setOpenCertModal] = useState(false);
+    const [editedCerts, setEditedCerts] = useState(false);
 
     const [certs, setCerts] = useState([]);
     const [fName, setFName] = useState(obj[0][FIELDS.FIRST]);
@@ -44,7 +44,7 @@ export default function ServiceProviderProfile(props) {
       let deleteDetails = {"cert_id": certID}
       callApiDeleteCert(deleteDetails)
       setEditedCerts(true)
-      console.log(editedCerts)
+      getCertData(id)
     }
 
     const handleCancel = () => {
@@ -75,6 +75,7 @@ export default function ServiceProviderProfile(props) {
 
     const handleConfirmAddCert = (updatedCert) => {
       let addCertDetails = {"cert_name": updatedCert, "service_provider_id": id}
+      setEditedCerts(true)
       callApiAddCert(addCertDetails)
       setOpenCertModal(false)
       getCertData(id)
@@ -98,8 +99,11 @@ export default function ServiceProviderProfile(props) {
       }
     
     useEffect(() => {
-        getCertData(id)
-    }, [JSON.stringify(certs)]);
+        if (certs.length === 0 || editedCerts) {
+          getCertData(id)
+          setEditedCerts(false)
+        }
+    }, [certs]);
 
     let getCertData = (id) => {
         callApiCerts(id)


### PR DESCRIPTION
Profile was not updating without reloading the page if a certification was added or deleted. It now does with this code.

Also removed a redundant navbar from the inbox page.